### PR TITLE
Corrected issue with unsupported versions not getting caught + comments/style

### DIFF
--- a/inventory.sample.yml
+++ b/inventory.sample.yml
@@ -2,7 +2,7 @@
 # inventory.yml
 #
 # This file is used by Ansible to define the hosts that the playbook
-# will perform actions on.  Below is the sample inventory provided by
+# will perform actions on. Below is the sample inventory provided by
 # this playbook which includes inline comments clarifying each section
 # and the items contained within it.
 #
@@ -22,9 +22,9 @@ wordpress:
     # Redis as part of the deployment.
     use_ultrastack: true
 
-    # When enabled, 'use_letsencrypt' signals to generate a LetsEncypt
-    # SSL as part of the deployment.  This is disabled by default to
-    # prevent a host from being ratelimited by the LetsEncrypt API
+    # When enabled, 'use_letsencrypt' signals to generate a Let's Encrypt
+    # SSL certificate as part of the deployment. This is disabled by default
+    # to prevent a host from being ratelimited by the Let's Encrypt API,
     # though additional conditions have been added to ensure that a
     # host meets the needed conditions to generate an SSL.
     #
@@ -33,10 +33,10 @@ wordpress:
     use_letsencrypt: false
 
   # Within the 'wordpress' group we may define 'hosts' that indicate
-  # the deployment targets for this playbook.
+  # the individual deployment targets for this playbook.
   hosts:
     # Within 'hosts' we may define an individual host, referenced in
-    # this example as 'domain.tld'.  This may be either a domain name
+    # this example as 'domain.tld'. This may be either a domain name
     # or IP address, based on your preference, provided it is able to
     # be reached.
     domain.tld:
@@ -45,7 +45,7 @@ wordpress:
       # user's '~/doc_root' directory.
       system_user: "wordpress"
 
-      # The domain associated with the WordPress installation.  Simply
+      # The domain associated with the WordPress installation. Simply
       # use the domain name itself without defining a protocol or
       # trailing '/' characters.
       site_domain: "domain.tld"
@@ -54,7 +54,7 @@ wordpress:
       site_email: "user@domain.tld"
 
       # The username of the WordPress administrator.
-      site_user: "example_username" # INSECURE!!  CHANGEME!!
+      site_user: "example_username" # INSECURE!! CHANGEME!!
 
       # The password of the WordPress administrator.
-      site_pass: "example_password" # INSECURE!!  CHANGEME!!
+      site_pass: "example_password" # INSECURE!! CHANGEME!!

--- a/site.deploy.yml
+++ b/site.deploy.yml
@@ -1,11 +1,17 @@
 ---
 # site.deploy.yml
 
+# To deploy the LAMP and UltraStack playbooks, we want to first ensure the
+# host meets basic requirements. We don't need to gather facts (gather_facts)
+# about this point. If any of the pretasks or tasks return an error, we will
+# abort the deployment (any_errors_fatal).
 - name: check that hosts meet the basic requirements
   any_errors_fatal: true
   gather_facts: false
   hosts: all
 
+  # Pretask: Confirm Python exists on the host. If Python exists, we'll collect
+  # facts about the host (setup) for use in subsequent tasks.
   pre_tasks:
     - name: check if some version of Python is installed and accessible
       raw: |-
@@ -15,7 +21,13 @@
     - name: Gather facts for later tasks
       setup:
 
+  # Tasks to check for the OS, LAMP services, and if Ansible
+  # is managing the host.
   tasks:
+    # Check for the following supported OSs on the host:
+    # CentOS: 7.6, 7.7, 8.0, 8.1
+    # Debian: Jessie (8), Stretch (9), Buster (10)
+    # Ubuntu: Xenial Xerus (16.04), Bionic Beaver (18.04)
     - name: check if host OS is supported
       fail:
         msg: >-
@@ -24,13 +36,13 @@
       changed_when: false
       failed_when: >-
         ansible_distribution not in targets.keys()
-        and (ansible_distribution_version not in target_versions
-        or ansible_distribution_major_version not in target_versions)
+        or (ansible_distribution_release not in target_versions
+        and ansible_distribution_version not in target_versions)
       vars:
         targets:
           CentOS: ["7.6", "7.7", "8.0", "8.1"]
-          Debian: ["8", "9", "10"]
-          Ubuntu: ["16.04", "18.04"]
+          Debian: ["jessie", "stretch", "buster"]
+          Ubuntu: ["xenial", "bionic"]
         target_versions: "{{ targets[ansible_distribution] }}"
 
     - name: check if this host is managed by Ansible
@@ -40,6 +52,9 @@
       failed_when: false
       register: ansible_deployed
 
+    # If ansible_deployed.changed is True, check for core LAMP services
+    # by checking their respective commands.
+    # If LAMP services already exist, lamp_installed.changed is True.
     - name: check if core LAMP services are present
       command: >
         command -v {{ item }}
@@ -54,6 +69,9 @@
       when:
         - ansible_deployed.changed
 
+    # If lamp_installed.changed and ansible_deployed.changed are both True,
+    # LAMP services are installed but the host isn't managed by Ansible.
+    # Abort the run and advise the removal of the LAMP services.
     - name: Fail if Ansible isn't managing this host
       fail:
         msg: >
@@ -65,6 +83,8 @@
         - lamp_installed.changed
         - ansible_deployed.changed
 
+# If we haven't failed by this point, we're ready to prep for
+# service and WordPress deployment.
 - name: Deploy WordPress to defined hosts in the 'wordpress' group
   any_errors_fatal: true
   gather_facts: false
@@ -83,6 +103,7 @@
         access_time: preserve
         modification_time: preserve
 
+  # Install the LAMP services and WordPress UltraStack packages.
   roles:
     - role: inmotionhosting.apache
     - role: inmotionhosting.mysql


### PR DESCRIPTION
Corrected an issue in which hosts running an distro that was _not_ a supported LTS version but was a similar major release could still pass (e.g. Ubuntu 18.10 vs 18.04).